### PR TITLE
Add assessment checklist and failure logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,21 @@
         <!-- Generated patient info will appear here -->
     </div>
 
+    <div id="assessment">
+        <h2>Assessment Checklist</h2>
+        <form id="assessmentForm">
+            <label><input type="checkbox" name="step" value="sceneSafety"> Scene safety / PPE</label>
+            <label><input type="checkbox" name="step" value="airway"> Assess airway</label>
+            <label><input type="checkbox" name="step" value="breathing"> Assess breathing</label>
+            <label><input type="checkbox" name="step" value="circulation"> Assess circulation</label>
+            <label><input type="checkbox" name="step" value="transportDecision"> Make transport decision</label>
+            <label><input type="checkbox" name="step" value="vitalSigns"> Obtain vital signs</label>
+            <label><input type="checkbox" name="step" value="reassessment"> Reassessment</label>
+            <button type="button" id="completeAssessmentBtn">Complete Assessment</button>
+        </form>
+        <div id="assessmentResult"></div>
+    </div>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,18 @@
 document.addEventListener('DOMContentLoaded', function() {
     const newPatientBtn = document.getElementById('newPatientBtn');
     const randomPatientBtn = document.getElementById('randomPatientBtn');
+    const completeAssessmentBtn = document.getElementById('completeAssessmentBtn');
+
+    const requiredSteps = ['sceneSafety', 'airway', 'breathing', 'circulation', 'transportDecision', 'vitalSigns', 'reassessment'];
+    const stepNames = {
+        sceneSafety: 'Scene safety / PPE',
+        airway: 'Assess airway',
+        breathing: 'Assess breathing',
+        circulation: 'Assess circulation',
+        transportDecision: 'Transport decision',
+        vitalSigns: 'Obtain vital signs',
+        reassessment: 'Reassessment'
+    };
 
     newPatientBtn.addEventListener('click', function() {
         const stability = document.getElementById('stability').value;
@@ -15,10 +27,25 @@ document.addEventListener('DOMContentLoaded', function() {
         const randomChiefComplaint = chiefComplaintOptions[Math.floor(Math.random() * chiefComplaintOptions.length)];
         generatePatient(randomStability, randomChiefComplaint);
     });
+
+    completeAssessmentBtn.addEventListener('click', function() {
+        const checked = Array.from(document.querySelectorAll('#assessmentForm input[type="checkbox"]:checked')).map(cb => cb.value);
+        const missing = requiredSteps.filter(step => !checked.includes(step));
+        const resultDiv = document.getElementById('assessmentResult');
+        if (missing.length > 0) {
+            const missingNames = missing.map(step => stepNames[step]).join(', ');
+            resultDiv.textContent = `Assessment failed: missing ${missingNames}.`;
+            resultDiv.style.color = 'red';
+        } else {
+            resultDiv.textContent = 'Assessment completed successfully!';
+            resultDiv.style.color = 'green';
+        }
+    });
 });
 
 function generatePatient(stability, chiefComplaint) {
     let patientData = {};
+    resetAssessment();
 
     switch(chiefComplaint) {
         case 'sob_asthma':
@@ -54,6 +81,15 @@ function displayPatientData(patientData) {
         const p = document.createElement('p');
         p.textContent = `${key}: ${value}`;
         patientInfoDiv.appendChild(p);
+    }
+}
+
+function resetAssessment() {
+    const checkboxes = document.querySelectorAll('#assessmentForm input[type="checkbox"]');
+    checkboxes.forEach(cb => cb.checked = false);
+    const resultDiv = document.getElementById('assessmentResult');
+    if (resultDiv) {
+        resultDiv.textContent = '';
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -28,3 +28,17 @@ body {
 #patientInfo p {
     margin: 5px 0;
 }
+
+#assessment {
+    margin-top: 20px;
+}
+
+#assessment label {
+    display: block;
+    margin: 5px 0;
+}
+
+#assessmentResult {
+    margin-top: 10px;
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- Expand UI with assessment checklist to mirror NREMT patient assessment sequence
- Evaluate completed steps and display failure when key items are missing
- Style new assessment section for clarity

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688e20ad26348328932908136e7e099c